### PR TITLE
Implement ML URL validation and enhanced scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,5 @@ GET /scrape?url=https://produto.mercadolivre.com.br/...
 
 1. O endpoint cria um driver Selenium em modo headless.
 2. O driver navega até a URL informada e coleta os principais elementos da página.
-3. O HTML obtido é enviado para o modelo de linguagem, que devolve os dados estruturados.
-4. A resposta da API é um JSON com essas informações.
+3. O HTML obtido é combinado com os cinco primeiros comentários do anúncio e enviado para o modelo de linguagem.
+4. O modelo retorna um JSON que inclui `percentagem` e `justificativa` sobre a originalidade do produto.

--- a/structuring_llm.py
+++ b/structuring_llm.py
@@ -23,9 +23,11 @@ Você recebe o HTML bruto de uma página de anúncio de cartucho HP. Retorne um 
 - valor_revisao: inteiro 
 - vendedor: nome da loja ou responsavel pela venda
 - quantidade_reviews: inteiro
-- quantidade_fotos: inteiro
-- classificacao_confianca: procure elementos que possam identificar se o produto é (ex: \"Original\", \"Pirata\", \"Suspeito\")
-Responda **somente** com um JSON válido.
+    - quantidade_fotos: inteiro
+    - classificacao_confianca: procure elementos que possam identificar se o produto é (ex: \"Original\", \"Pirata\", \"Suspeito\")
+    - percentagem: porcentagem de confiança de o produto ser original
+    - justificativa: texto curto descrevendo os critérios usados para a classificação
+    Responda **somente** com um JSON válido.
 """
 
 def extract_structured(html: str) -> dict:


### PR DESCRIPTION
## Summary
- validate Mercado Livre URLs before scraping
- scrape 5 comments and append to HTML
- return `percentagem` and `justificativa` from the LLM
- document the updated workflow

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6850967e147c832eb16cea00f37b04a8